### PR TITLE
Optimize Scene Loading for Frame Stability and memory usage

### DIFF
--- a/Assets/IRXRClient/Scripts/IRXRNetManager.cs
+++ b/Assets/IRXRClient/Scripts/IRXRNetManager.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json;
 using System.Net.Sockets;
 using System.Collections.Generic;
 using System.Net.NetworkInformation;
+using System.Threading.Tasks;
 
 public enum ServerPort {
   Discovery = 7720,
@@ -48,10 +49,11 @@ public class IRXRNetManager : Singleton<IRXRNetManager> {
   // publisher socket
   private PublisherSocket _pubSocket;
   private RequestSocket _reqSocket;
+
   private ResponseSocket _resSocket;
   private Dictionary<string, Func<string, string>> _serviceCallbacks;
 
-  private float lastTimeStamp;
+  private float lastTimeStamp = -1.0f;
   private bool isConnected = false;
   private float timeOffset = 0.0f;
   public float TimeOffset
@@ -75,6 +77,7 @@ public class IRXRNetManager : Singleton<IRXRNetManager> {
     _pubSocket = new PublisherSocket();
     // the collection of all sockets
     _sockets = new List<NetMQSocket> { _reqSocket, _resSocket, _subSocket, _pubSocket };
+
     // Default host name
     if (PlayerPrefs.HasKey("HostName"))
     {
@@ -98,11 +101,10 @@ public class IRXRNetManager : Singleton<IRXRNetManager> {
     OnConnectionStart += () => { isConnected = true; };
     ConnectionSpin += () => {};
     OnDisconnected += StopConnection;
-    lastTimeStamp = -1.0f;
     RegisterServiceCallback("ChangeHostName", ChangeHoseName);
   }
 
-  void Update() {
+  async void Update() {
     ConnectionSpin.Invoke();
     if (_discoveryClient.Available == 0) return; // there's no message to read
     IPEndPoint endPoint = new IPEndPoint(IPAddress.Any, 0);
@@ -121,7 +123,7 @@ public class IRXRNetManager : Singleton<IRXRNetManager> {
       Debug.Log($"Discovered server at {_serverInfo.ip} with local IP {_localInfo.ip}");
       StartConnection();
       RegisterInfo2Server();
-      OnConnectionStart.Invoke();
+      await Task.Run(() => OnConnectionStart.Invoke());
     }
     lastTimeStamp = Time.realtimeSinceStartup;
   }
@@ -152,6 +154,7 @@ public class IRXRNetManager : Singleton<IRXRNetManager> {
   // It may stuck if the server is not responding,
   // which will cause the Unity Editor to freeze.
   public string RequestString(string service, string request = "") {
+    
     _reqSocket.SendFrame($"{service}:{request}");
     // string result = _reqSocket.TryReceiveFrame(out bool more);
     if (!_reqSocket.TryReceiveFrameString(TimeSpan.FromMilliseconds(5000), out string result, out bool more)) {
@@ -160,18 +163,20 @@ public class IRXRNetManager : Singleton<IRXRNetManager> {
     }
     while(more) result += _reqSocket.ReceiveFrameString(out more);
     return result;
+    
   }
 
   public List<byte> RequestBytes(string service, string request = "") {
+
     _reqSocket.SendFrame($"{service}:{request}");
-    List<byte> result = new List<byte>();
-    if (!_reqSocket.TryReceiveFrameBytes(TimeSpan.FromMilliseconds(5000), out byte[] bytes, out bool more)) {
-      Debug.LogWarning("Request Timeout");
+    if (!_reqSocket.TryReceiveFrameBytes(TimeSpan.FromMilliseconds(10000), out byte[] bytes, out bool more)) {
+      Debug.LogWarning($"Request Timeout");
+      return new List<byte>();
     }
-    else {      
-      result.AddRange(bytes);
-      while (more) result.AddRange(_reqSocket.ReceiveFrameBytes(out more));
-    }
+
+    List<byte> result = new List<byte>(bytes);
+    result.AddRange(bytes);
+    while (more) result.AddRange(_reqSocket.ReceiveFrameBytes(out more));
     return result;
   }
 
@@ -285,10 +290,9 @@ public class IRXRNetManager : Singleton<IRXRNetManager> {
       UnicastIPAddressInformationCollection unicastIPAddresses = ipProperties.UnicastAddresses;
       foreach (UnicastIPAddressInformation ipInfo in unicastIPAddresses)
       {
-        if (ipInfo.Address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
+        if (ipInfo.Address.AddressFamily == AddressFamily.InterNetwork)
         {
           IPAddress localIP = ipInfo.Address;
-          Debug.Log($"Local IP: {localIP}");
           // Check if the IP is in the same subnet
           if (IsInSameSubnet(inputIP, localIP, subnetMask))
           {

--- a/Assets/SceneLoader/Scripts/SimData.cs
+++ b/Assets/SceneLoader/Scripts/SimData.cs
@@ -50,13 +50,6 @@ public class SimAsset {
   public string name;
 }
 
-public class SimMeshData {
-  public int[] indices;
-  public Vector3[] vertices;
-  public Vector3[] normals;
-  public Vector2[] uvs;
-}
-
 public class SimMesh : SimAsset {
   public string dataHash;
   public List<int> indicesLayout;
@@ -69,10 +62,6 @@ public class SimMesh : SimAsset {
 
   [JsonIgnore]
   public Mesh compiledMesh;
-
-  
-  [JsonIgnore]
-  public SimMeshData rawData;
 }
 
 public class SimMaterial : SimAsset {
@@ -96,9 +85,6 @@ public class SimTexture  : SimAsset {
   public int height;
 
   public string texureType;
-  
-  [JsonIgnore]
-  public byte[] textureData;
 
   [JsonIgnore]
   public Texture compiledTexture;

--- a/Assets/SceneLoader/Scripts/SimLoader.cs
+++ b/Assets/SceneLoader/Scripts/SimLoader.cs
@@ -3,10 +3,16 @@ using UnityEngine;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
+using System.Linq;
+using System.IO.Pipes;
+using System.Collections.Concurrent;
 
 
 public class SceneLoader : MonoBehaviour {
 
+
+  private object updateActionLock = new();
   private Action updateAction;
   public Action OnSceneLoaded;
   public Action OnSceneCleared;
@@ -15,20 +21,12 @@ public class SceneLoader : MonoBehaviour {
   private SimScene _simScene;
   private Dictionary<string, Transform> _simObjTrans = new Dictionary<string, Transform>();
 
-  private Dictionary<string, SimMesh> _simMeshes;
-  private Dictionary<string, SimMaterial> _simMaterials;
-  private Dictionary<string, SimTexture> _simTextures;
-  private Dictionary<string, Mesh> _cachedMeshes;
-  private Dictionary<string, Texture> _cachedTextures;
+  private Dictionary<string, SimMesh> _simMeshes = new();
+  private Dictionary<string, SimMaterial> _simMaterials = new();
+  private Dictionary<string, SimTexture> _simTextures = new();
+  private Dictionary<string, Mesh> _cachedMeshes  = new();
+  private Dictionary<string, Texture> _cachedTextures = new();
 
-  void Awake() {
-    _simMeshes = new();
-    _simMaterials = new();
-    _simTextures = new();
-
-    _cachedTextures = new();
-    _cachedMeshes = new();
-  }
 
   void Start() {
     _netManager = IRXRNetManager.Instance;
@@ -44,29 +42,33 @@ public class SceneLoader : MonoBehaviour {
     var local_watch = new System.Diagnostics.Stopwatch();
     local_watch.Start();
     Debug.Log("Building Scene");
-    ProcessAsset(); // Compile Meshes, textures and Materials can only be done on the main thread
     _simSceneObj = CreateObject(gameObject.transform, _simScene.root);
     local_watch.Stop();
     Debug.Log($"Building Scene in {local_watch.ElapsedMilliseconds} ms");
-    updateAction -= BuildScene;
     OnSceneLoaded.Invoke();
   }
 
-  void DownloadScene() {
+  private void DownloadScene() {
+
+    var local_watch = new System.Diagnostics.Stopwatch();
+    local_watch.Start();
+
     if (!_netManager.CheckServerService("Scene")) {
       Debug.LogWarning("Scene Service is not found");
       return;
     }
-    float downloadStartTime = Time.realtimeSinceStartup;
+    
     string asset_info = _netManager.RequestString("Scene");
-    if (asset_info == "Invild Service") {
+    
+    if (asset_info == "Invalid Service") {
       Debug.LogWarning("Invalid Service");
       return;
     }
+
     _simScene = JsonConvert.DeserializeObject<SimScene>(asset_info);
     DownloadAssets(_simScene);
-    float timeSpent = (Time.realtimeSinceStartup - downloadStartTime) * 1000;
-    Debug.Log($"Downloaded Scene in {(int)timeSpent} ms");
+    local_watch.Stop();
+    Debug.Log($"Downloaded Scene in {local_watch.ElapsedMilliseconds} ms");
     updateAction += BuildScene;
   }
 
@@ -74,39 +76,40 @@ public class SceneLoader : MonoBehaviour {
     _simMeshes.Clear();
     _simMaterials.Clear();
     _simTextures.Clear();
-    scene.meshes.ForEach(DownloadMesh);
-    scene.textures.ForEach(DownloadTexture);
+
+    scene.meshes.ForEach(mesh => DownloadMesh(mesh));
+    scene.textures.ForEach(texture => DownloadTexture(texture));  
+    scene.materials.ForEach(material => _simMaterials.Add(material.name, material));
   }
 
   private void DownloadMesh(SimMesh mesh) {
-    if (_cachedMeshes.TryGetValue(mesh.dataHash, out Mesh cached)) {
-      mesh.compiledMesh = cached;
-      _simMeshes.Add(mesh.name, mesh);
-      return;
+    if (!_cachedMeshes.TryGetValue(mesh.dataHash, out mesh.compiledMesh)) {
+      byte[] data = _netManager.RequestBytes("Asset", mesh.dataHash).ToArray();
+      RunOnMainThread(() => ProcessMesh(mesh, data));
     }
-    Span<byte> data = _netManager.RequestBytes("Asset", mesh.dataHash).ToArray();
-    mesh.rawData = new SimMeshData
-    {
-      indices = MemoryMarshal.Cast<byte, int>(data.Slice(mesh.indicesLayout[0], mesh.indicesLayout[1] * sizeof(int))).ToArray(),
-      vertices = MemoryMarshal.Cast<byte, Vector3>(data.Slice(mesh.verticesLayout[0], mesh.verticesLayout[1] * sizeof(float))).ToArray(),
-      normals = MemoryMarshal.Cast<byte, Vector3>(data.Slice(mesh.normalsLayout[0], mesh.normalsLayout[1] * sizeof(float))).ToArray(),
-      uvs = MemoryMarshal.Cast<byte, Vector2>(data.Slice(mesh.uvLayout[0], mesh.uvLayout[1] * sizeof(float))).ToArray(),
-    };
+    _simMeshes.TryAdd(mesh.name, mesh);
   }
 
   private void DownloadTexture(SimTexture texture) {
-    if (_cachedTextures.TryGetValue(texture.dataHash, out Texture cached)){
-      texture.compiledTexture = cached;
-    } else {
-      texture.textureData = _netManager.RequestBytes("Asset", texture.dataHash).ToArray();
+    if (!_cachedTextures.TryGetValue(texture.dataHash, out texture.compiledTexture)){
+      byte[] data = _netManager.RequestBytes("Asset", texture.dataHash).ToArray();
+      RunOnMainThread(() => ProcessTexture(texture, data));
     }
-
-    _simTextures.Add(texture.name, texture);
+    _simTextures.TryAdd(texture.name, texture);
   }
 
 
+  void RunOnMainThread(Action action) {
+    lock(updateActionLock) {
+      updateAction += action;
+    }
+  }
+
   void Update() {
-    updateAction.Invoke();
+    lock(updateActionLock) {
+      updateAction.Invoke();
+      updateAction = () => { };
+    }
   }
 
 
@@ -117,9 +120,10 @@ public class SceneLoader : MonoBehaviour {
   }
 
 
-  GameObject CreateObject(Transform root, SimBody body, string name = null) {
-    GameObject bodyRoot = new GameObject(name != null ? name : body.name);
-    if (root != null)  bodyRoot.transform.SetParent(root, false);
+  GameObject CreateObject(Transform root, SimBody body) {
+    
+    GameObject bodyRoot = new GameObject(body.name);
+    bodyRoot.transform.SetParent(root, false);
     ApplyTransform(bodyRoot.transform, body.trans);
 
     GameObject VisualContainer = new GameObject("Visuals");
@@ -163,22 +167,14 @@ public class SceneLoader : MonoBehaviour {
 
       Renderer renderer = visualObj.GetComponent<Renderer>();
       if (visual.material != null) {
-        renderer.material = GetMaterial(visual.material).compiledMaterial;
+        var material = GetMaterial(visual.material);
+        if (material.compiledMaterial == null) {
+          ProcessMaterial(material);
+        }
+        renderer.material = material.compiledMaterial;
       }
       else {
-        renderer.material = new Material(Shader.Find("Standard"));
-        if (visual.color[3] < 1)
-        {
-          renderer.material.SetFloat("_Mode", 2);
-          renderer.material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
-          renderer.material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
-          renderer.material.SetInt("_ZWrite", 0);
-          renderer.material.DisableKeyword("_ALPHATEST_ON");
-          renderer.material.EnableKeyword("_ALPHABLEND_ON");
-          renderer.material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
-          renderer.material.renderQueue = 3000;
-        }
-        renderer.material.SetColor("_Color", new Color(visual.color[0], visual.color[1], visual.color[2], visual.color[3]));
+        renderer.material = CreateColorMaterial(visual.color);
       }
 
       visualObj.transform.SetParent(VisualContainer.transform, false);
@@ -198,31 +194,41 @@ public class SceneLoader : MonoBehaviour {
     _simMeshes.Clear();
     _simMaterials.Clear();
     _simTextures.Clear();
-
-    _cachedTextures.Clear();
-    _cachedMeshes.Clear();
   }
 
   public SimMesh GetMesh(string id) => _simMeshes[id];
   public SimTexture GetTexture(string id) => _simTextures[id];
   public SimMaterial GetMaterial(string id) => _simMaterials[id];
-  public void ProcessAsset() {
-    _simScene.meshes.ForEach(ProcessMesh);
-    _simScene.materials.ForEach(ProcessMaterial);
+  
+  public Material CreateColorMaterial(List<float> color) {
+    var material = new Material(Shader.Find("Standard"));
+    if (color[3] < 1)
+    {
+      material.SetFloat("_Mode", 2);
+      material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
+      material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+      material.SetInt("_ZWrite", 0);
+      material.DisableKeyword("_ALPHATEST_ON");
+      material.EnableKeyword("_ALPHABLEND_ON");
+      material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+      material.renderQueue = 3000;
+    }
+    material.SetColor("_Color", new Color(color[0], color[1], color[2], color[3]));
+    return material;
   }
 
-  public void ProcessMesh(SimAsset asset) {
+  public void ProcessMesh(SimAsset asset, byte[] data) {
     SimMesh mesh = (SimMesh)asset;
 
-    mesh.compiledMesh = new Mesh{
-      name = mesh.name,
-      vertices = mesh.rawData.vertices,
-      normals = mesh.rawData.normals,
-      triangles = mesh.rawData.indices,
-      uv = mesh.rawData.uvs,
-    };
+    var indices = 
 
-    mesh.rawData = null;
+    mesh.compiledMesh = new Mesh{
+      name = asset.name, 
+      triangles = MemoryMarshal.Cast<byte, int>(new ReadOnlySpan<byte>(data, mesh.indicesLayout[0], mesh.indicesLayout[1] * sizeof(int))).ToArray(),
+      vertices = MemoryMarshal.Cast<byte, Vector3>(new ReadOnlySpan<byte>(data, mesh.verticesLayout[0], mesh.verticesLayout[1] * sizeof(float))).ToArray(),
+      normals = MemoryMarshal.Cast<byte, Vector3>(new ReadOnlySpan<byte>(data, mesh.normalsLayout[0], mesh.normalsLayout[1] * sizeof(float))).ToArray(),
+      uv = MemoryMarshal.Cast<byte, Vector2>(new ReadOnlySpan<byte>(data, mesh.uvLayout[0], mesh.uvLayout[1] * sizeof(float))).ToArray()
+    };
 
     _cachedMeshes[mesh.dataHash] = mesh.compiledMesh;
     _simMeshes[mesh.name] = mesh;
@@ -241,8 +247,9 @@ public class SceneLoader : MonoBehaviour {
 
     if (material.texture != null) {
       SimTexture texture = _simTextures[material.texture];
-      if (texture.compiledTexture == null) 
-        ProcessTexture(texture);
+
+      _simTextures[material.texture] = texture; // Just to be shure the texture is updated (investigate)
+
       mat.mainTexture = texture.compiledTexture;
       mat.mainTextureScale = new Vector2(material.textureSize[0], material.textureSize[1]);
     }
@@ -251,15 +258,13 @@ public class SceneLoader : MonoBehaviour {
     _simMaterials[material.name] = material;
   }
 
-  public SimAsset ProcessTexture(SimAsset asset) {
+  public SimAsset ProcessTexture(SimAsset asset, byte[] data) {
     SimTexture simTexture = (SimTexture)asset;
 
     var tex = new Texture2D(simTexture.width, simTexture.height, TextureFormat.RGB24, false);
-    tex.LoadRawTextureData(simTexture.textureData);
+    tex.LoadRawTextureData(data);
     tex.Apply();
-
-    simTexture.textureData = null;
-
+    
     simTexture.compiledTexture = tex;
     _cachedTextures[simTexture.dataHash] = simTexture.compiledTexture;
     return asset;

--- a/Assets/SceneLoader/Scripts/SimLoader.cs
+++ b/Assets/SceneLoader/Scripts/SimLoader.cs
@@ -209,7 +209,6 @@ public class SceneLoader : MonoBehaviour {
   public void ProcessAsset() {
     _simScene.meshes.ForEach(ProcessMesh);
     _simScene.materials.ForEach(ProcessMaterial);
-    _simScene.textures.ForEach(ProcessTexture);  
   }
 
   public void ProcessMesh(SimAsset asset) {
@@ -222,6 +221,9 @@ public class SceneLoader : MonoBehaviour {
       triangles = mesh.rawData.indices,
       uv = mesh.rawData.uvs,
     };
+
+    mesh.rawData = null;
+
     _cachedMeshes[mesh.dataHash] = mesh.compiledMesh;
     _simMeshes[mesh.name] = mesh;
   }
@@ -239,7 +241,8 @@ public class SceneLoader : MonoBehaviour {
 
     if (material.texture != null) {
       SimTexture texture = _simTextures[material.texture];
-      if (texture.compiledTexture == null) ProcessTexture(texture);
+      if (texture.compiledTexture == null) 
+        ProcessTexture(texture);
       mat.mainTexture = texture.compiledTexture;
       mat.mainTextureScale = new Vector2(material.textureSize[0], material.textureSize[1]);
     }
@@ -248,15 +251,18 @@ public class SceneLoader : MonoBehaviour {
     _simMaterials[material.name] = material;
   }
 
-  public void ProcessTexture(SimAsset asset) {
+  public SimAsset ProcessTexture(SimAsset asset) {
     SimTexture simTexture = (SimTexture)asset;
 
     var tex = new Texture2D(simTexture.width, simTexture.height, TextureFormat.RGB24, false);
     tex.LoadRawTextureData(simTexture.textureData);
     tex.Apply();
 
+    simTexture.textureData = null;
+
     simTexture.compiledTexture = tex;
     _cachedTextures[simTexture.dataHash] = simTexture.compiledTexture;
+    return asset;
   }
 
   public Dictionary<string, Transform> GetObjectsTrans() {


### PR DESCRIPTION
- Images were previously loaded double
- meshes and textures are now directly created after loading, no need to save the intermediate data
- Scene loading now runs in  a separate thread, so the editor / application does not freeze during usage